### PR TITLE
Fix CSP to allow Iconify API connections

### DIFF
--- a/server.js
+++ b/server.js
@@ -39,7 +39,9 @@ app.use(
         "'self'", 
         'https://api.github.com', 
         'https://fonts.googleapis.com',
-        'https://fonts.gstatic.com'
+        'https://fonts.gstatic.com',
+        'https://api.iconify.design',
+        'https://cdn.jsdelivr.net'
       ],
       fontSrc: ["'self'", 'https://fonts.gstatic.com', 'data:'],
       objectSrc: ["'self'"],  // Allow PDFs

--- a/src/utils/security.js
+++ b/src/utils/security.js
@@ -23,14 +23,14 @@ export const securityConfig = {
 export const applyCSP = () => {
   if (!securityConfig.enableCSP) return;
   
-  // Define CSP directives - remove jsdelivr reference
+  // Define CSP directives
   const cspDirectives = [
     "default-src 'self'",
-    "script-src 'self' 'unsafe-inline' https://api.github.com",
+    "script-src 'self' 'unsafe-inline' https://api.github.com https://code.iconify.design",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: https://avatars.githubusercontent.com https://*.githubusercontent.com",
     "font-src 'self' https://fonts.gstatic.com",
-    "connect-src 'self' https://api.github.com",
+    "connect-src 'self' https://api.github.com https://api.iconify.design https://cdn.jsdelivr.net",
     "frame-src 'none'",
     "object-src 'none'"
   ].join('; ');
@@ -72,7 +72,7 @@ export const applyXXSSProtection = () => {
   // Add CSP directive that helps with XSS protection
   const cspMeta = document.createElement('meta');
   cspMeta.httpEquiv = 'Content-Security-Policy';
-  cspMeta.content = "script-src 'self' 'unsafe-inline' https://api.github.com";
+  cspMeta.content = "script-src 'self' 'unsafe-inline' https://api.github.com https://code.iconify.design";
   document.head.appendChild(cspMeta);
   
   // Add HTML encoding helper to window object


### PR DESCRIPTION
# Fix Content Security Policy for Iconify API

## Summary
- Add required CSP directives to allow Iconify icon loading
- Fix icon rendering issues caused by CSP blocking API connections

## Changes Made
- Added `api.iconify.design` to the connectSrc CSP directives
- Added `cdn.jsdelivr.net` as fallback for Iconify content
- Updated CSP directives in both server.js and client-side fallback in security.js
- Added iconify domains to script-src CSP directives

## Test Plan
- Verified that all tests pass (50 tests across 8 test suites)
- Manual testing will be required to ensure icon loading works properly in the browser

## Related Issues
The previous PR migrated from Font Awesome to Iconify but didn't properly configure CSP for the new icon API. This PR resolves that issue.
